### PR TITLE
pme: set the gpu's default_pwrlevel to 6

### DIFF
--- a/rootdir/etc/init.qcom.power.rc
+++ b/rootdir/etc/init.qcom.power.rc
@@ -105,6 +105,9 @@ on enable-low-power
     # Enable all low power modes
     write /sys/module/lpm_levels/parameters/sleep_disabled "N"
 
+    # Set idle GPU to 133 Mhz
+    write /sys/class/kgsl/kgsl-3d0/default_pwrlevel 6
+
     # Set perfd properties
     rm /data/system/perfd/default_values
     start perfd


### PR DESCRIPTION
* we have one step more than 8992/8994 devices

* lower the default powerlevel from 5 (default) to 6
* This causes the default freq to drop from 214Mhz to 133Mhz
 -> leads to free power savings since we can run without issues on 133Mhz for normal usecases

Change-Id: Ic84e526e4e87fbd28e607ac04218408a4550f569
Signed-off-by: Alex Naidis <alex.naidis@linux.com>